### PR TITLE
[ztp] fix bug: con't find config command, absolute path is required for config command 

### DIFF
--- a/src/usr/lib/ztp/dhcp/inband-ztp-ip
+++ b/src/usr/lib/ztp/dhcp/inband-ztp-ip
@@ -38,7 +38,7 @@ case $reason in
         if inband_interface_check ${interface} ; then
             if [ -n "$old_ip_address" ] && [ -n "$old_subnet_mask" ]; then
                 prefix=$(IPprefix_by_netmask "${old_subnet_mask}")
-                config interface ip remove ${interface} ${old_ip_address}${prefix}
+                /usr/local/bin/config interface ip remove ${interface} ${old_ip_address}${prefix}
             fi
         fi
         ;;
@@ -47,11 +47,11 @@ case $reason in
             if [ -n "$new_ip_address" ] && [ -n "$new_subnet_mask" ]; then
                 if [ -n "$old_ip_address" ] && [ -n "$old_subnet_mask" ]; then
                     prefix=$(IPprefix_by_netmask "${old_subnet_mask}")
-                    config interface ip remove ${interface} ${old_ip_address}${prefix}
+                    /usr/local/bin/config interface ip remove ${interface} ${old_ip_address}${prefix}
                 fi
                 prefix=$(IPprefix_by_netmask "${new_subnet_mask}")
                 if [ "${prefix}" != "/0" ]; then
-                    config interface ip add ${interface} ${new_ip_address}${prefix}
+                    /usr/local/bin/config interface ip add ${interface} ${new_ip_address}${prefix}
                 fi
             fi
         fi

--- a/src/usr/lib/ztp/dhcp/inband-ztp-ip6
+++ b/src/usr/lib/ztp/dhcp/inband-ztp-ip6
@@ -32,7 +32,7 @@ case $reason in
                 else
                     old_prefixlen=128
                 fi
-                config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
+                /usr/local/bin/config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
             fi
         fi
         ;;
@@ -45,14 +45,14 @@ case $reason in
                     else
                         old_prefixlen=128
                     fi
-                    config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
+                    /usr/local/bin/config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
                 fi
                 if [ -n "${new_ip6_prefixlen}" ]; then
                     prefixlen=${new_ip6_prefixlen}
                 else
                     prefixlen=128
                 fi
-                config interface ip add ${interface} ${new_ip6_address}/${new_ip6_prefixlen}
+                /usr/local/bin/config interface ip add ${interface} ${new_ip6_address}/${new_ip6_prefixlen}
             fi
         fi
         ;;


### PR DESCRIPTION
Signed-off-by: PinghaoQu  qu.pinghao@h3c.com

Why I did it


 The syslog printed the following errors  when I testted ztp function：
```
sonic INFO networking[795764]: /etc/dhcp/dhclient-enter-hooks.d/inband-ztp-ip: line 44: config: command not found
sonic ERR root: /etc/dhcp/dhclient-enter-hooks.d/inband-ztp-ip returned non-zero exit status 127
```

then, I echo the value of  $PATH in inband-ztp-ip file , It's PATH=/usr/sbin:/sbin:/bin:/usr/sbin:/usr/bin. I  found that the value of $PATH is passed in by dhclient process(dhclient process invoke the dhclient-script script, and dhclient-script invoke inband-ztp-ip)。

 isc-dhcp/client/dhclient.c :
```
int script_go(struct client_state *client)
{
char *scriptName;
char *argv [2];
char **envp;
static char client_path [] = CLIENT_PATH;
int i;
struct string_list *sp, *next;
int pid, wpid, wstatus;

...
      
/* Set $PATH. */
envp [i++] = client_path;
envp [i] = (char *)0;
```
The 'CLIETN_PATH' is defined in Makefile， isc-dhcp/dhclient/Makefile.am：
`AM_CPPFLAGS = -DCLIENT_PATH='"PATH=$(sbindir):/sbin:/bin:/usr/sbin:/usr/bin"'`

in the past, the installation directory of the config comand was `/usr/bin/` , but now it has changed to `/usr/local/bin`.
so，i think that we need add absolute path to config command in inband-ztp-ip/inband-ztp-ip6 file !


How I did it
Add absolute path

How to verify it
sudo config ztp run
