### PR TITLE
[dhclient]Fix dhclient-hook inband-ztp permission errors.

### DIFF
--- a/src/usr/lib/ztp/dhcp/inband-ztp-ip
+++ b/src/usr/lib/ztp/dhcp/inband-ztp-ip
@@ -38,7 +38,7 @@ case $reason in
         if inband_interface_check ${interface} ; then
             if [ -n "$old_ip_address" ] && [ -n "$old_subnet_mask" ]; then
                 prefix=$(IPprefix_by_netmask "${old_subnet_mask}")
-                config interface ip remove ${interface} ${old_ip_address}${prefix}
+                sudo config interface ip remove ${interface} ${old_ip_address}${prefix}
             fi
         fi
         ;;
@@ -47,11 +47,11 @@ case $reason in
             if [ -n "$new_ip_address" ] && [ -n "$new_subnet_mask" ]; then
                 if [ -n "$old_ip_address" ] && [ -n "$old_subnet_mask" ]; then
                     prefix=$(IPprefix_by_netmask "${old_subnet_mask}")
-                    config interface ip remove ${interface} ${old_ip_address}${prefix}
+                    sudo config interface ip remove ${interface} ${old_ip_address}${prefix}
                 fi
                 prefix=$(IPprefix_by_netmask "${new_subnet_mask}")
                 if [ "${prefix}" != "/0" ]; then
-                    config interface ip add ${interface} ${new_ip_address}${prefix}
+                    sudo config interface ip add ${interface} ${new_ip_address}${prefix}
                 fi
             fi
         fi

--- a/src/usr/lib/ztp/dhcp/inband-ztp-ip6
+++ b/src/usr/lib/ztp/dhcp/inband-ztp-ip6
@@ -32,7 +32,7 @@ case $reason in
                 else
                     old_prefixlen=128
                 fi
-                config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
+                sudo config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
             fi
         fi
         ;;
@@ -45,14 +45,14 @@ case $reason in
                     else
                         old_prefixlen=128
                     fi
-                    config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
+                    sudo config interface ip remove ${interface} ${old_ip6_address}/${old_prefixlen}
                 fi
                 if [ -n "${new_ip6_prefixlen}" ]; then
                     prefixlen=${new_ip6_prefixlen}
                 else
                     prefixlen=128
                 fi
-                config interface ip add ${interface} ${new_ip6_address}/${new_ip6_prefixlen}
+                sudo config interface ip add ${interface} ${new_ip6_address}/${new_ip6_prefixlen}
             fi
         fi
         ;;


### PR DESCRIPTION
**What I did**

When ZTP executes DHCP, there is an insufficient privilege to set the IP address into the chip.

**How I did it**

By using the "sudo" command, ZTP can elevate its privilege to set the DHCP IP address