### PR TITLE
[ztp] Fix race between ztp and rsyslog-config

### DIFF
--- a/debian/ztp.service
+++ b/debian/ztp.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SONiC Zero Touch Provisioning service
 Wants=config-setup.service
-After=config-setup.service interfaces-config.service
+After=config-setup.service interfaces-config.service rsyslog-config.service
 
 [Service]
 EnvironmentFile=-/etc/default/ztp


### PR DESCRIPTION
     - ZTP service restarts rsyslog service when it is shutting down. There
       can be a situation where rsyslog-config service is operational and
       restarting rsyslog.service.

     - The proposed changes start ztp.service after rsyslog-config.service
       exits.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/13798
