### PR TITLE
[ZTP] bufsize=1 not supported in binary mode

### DIFF
--- a/src/usr/lib/python3/dist-packages/ztp/ZTPLib.py
+++ b/src/usr/lib/python3/dist-packages/ztp/ZTPLib.py
@@ -95,7 +95,7 @@ def runCommand(cmd, capture_stdout=True, use_shell=False):
             else:
                 shcmd = cmd
         if capture_stdout is True:
-            proc = subprocess.Popen(shcmd, shell=use_shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, close_fds=True)
+            proc = subprocess.Popen(shcmd, shell=use_shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
             pid = proc.pid
             runcmd_pids.append(pid)
             output_stdout, output_stderr = proc.communicate()


### PR DESCRIPTION
In Python 3.8, line buffering (buffering=1) isn't supported in binary mode