### PR TITLE
[ZTP] 'config reload' use -f to avoid system checks

### DIFF
--- a/src/usr/lib/ztp/plugins/configdb-json
+++ b/src/usr/lib/ztp/plugins/configdb-json
@@ -205,7 +205,7 @@ class ConfigDBJson:
             self.__stop_dhcp()
             logger.info('configdb-json: Reloading config_db.json to Config DB.')
             updateActivity('configdb-json: Reloading config_db.json to Config DB')
-            cmd += 'reload'
+            cmd += 'reload -f'
         else:
             logger.info('configdb-json: Applying config_db.json to Config DB.')
             updateActivity('configdb-json: Applying config_db.json to Config DB')


### PR DESCRIPTION
sometimes configdb-json didn't take effect, and it displayed: 
--
Aug 13 08:51:12.048103 sonic INFO sonic-ztp[30764]: configdb-json: Reloading config_db.json to Config DB. 
Aug 13 08:51:12.586370 sonic INFO sonic-ztp[35241]: SwSS container is not ready. Retry later or use -f to avoid system checks