### PR TITLE
SNMP plugin fix for single attribute failure

### DIFF
--- a/src/usr/lib/ztp/plugins/snmp
+++ b/src/usr/lib/ztp/plugins/snmp
@@ -93,6 +93,8 @@ class Snmp:
         # Extract data from the section which is relevant to the snmp plugin
         no_section = True
         restart_agent = False
+        community_ro = None
+        snmp_location = None
         try:
             section_data = obj_section.jsonDict.get(section_name)
             restart_agent = getField(section_data, 'restart-agent', bool, default_value=False)


### PR DESCRIPTION
Why I did it
SNMP plugin fails with "UnboundLocalError: local variable 'snmp_location' referenced before assignment" when only community-ro attribute is specified and vice-versa.

Logs : 

Ztp json file :
```
{
  "ztp": {
     "snmp": {
              "community-ro": "private"
     },
     "restart-ztp-no-config": false
   }
}


Error message:
=============
[10646.574330] sonic-ztp[98907]:   self.stderr = io.open(errread, 'rb', bufsize)
[10646.590245] sonic-ztp[98907]: Traceback (most recent call last):
[10646.590321] sonic-ztp[98907]:   File "/usr/lib/ztp/plugins/snmp", line 149, in <module>
[10646.590407] sonic-ztp[98907]:     snmp.main()
[10646.590437] sonic-ztp[98907]:   File "/usr/lib/ztp/plugins/snmp", line 127, in main
[10646.594205] sonic-ztp[98907]:     if  snmp_location is not None:
[10646.594240] sonic-ztp[98907]: UnboundLocalError: local variable 'snmp_location' referenced before assignment

```
How I did it
Initialized the community_ro  and snmp_location variables to None to avoid issue scenario.

How to verify it
Specify snmp_location  or community-ro atrribute alone in ztp json file and verified the same.