### PR TITLE
[ZTP] Use config db instead of ZTP configuration profile while dhcp d…

### DIFF
--- a/src/etc/default/ztp
+++ b/src/etc/default/ztp
@@ -18,3 +18,6 @@ COVERAGE=""
 # Change below to provide command coverage.py tool.
 # (python3-coverage run --append is used if not specified)
 COVERAGE_CMD=""
+
+# Use ZTP configuration profile (default) or config_db
+USE_DEFAULT_CONFIG="yes"

--- a/src/usr/lib/ztp/sonic-ztp
+++ b/src/usr/lib/ztp/sonic-ztp
@@ -37,6 +37,10 @@ start()
     # Custom ztp_cfg.json file
     [ "${CONFIG_JSON}" != "" ] && CONFIG_JSON_ARGS="-C ${CONFIG_JSON}"
 
+    # Use ZTP configuration profile (default) or config_db
+    [ "${USE_DEFAULT_CONFIG}" = "no" ] && CONFIG_DB_ARGS="-o"
+
+
     if [ "${COVERAGE}" = "yes" ]; then
         if which python3-coverage > /dev/null; then
             [ "${COVERAGE_CMD}" = "" ] && COVERAGE_EXP="python3-coverage run --append"
@@ -49,7 +53,7 @@ start()
     fi
 
     # Kickstart ZTP service daemon
-    ${COVERAGE_EXP} ${ZTP_ENGINE} ${DEBUG_ARGS} ${TEST_ARGS} ${CONFIG_JSON_ARGS} &
+    ${COVERAGE_EXP} ${ZTP_ENGINE} ${DEBUG_ARGS} ${TEST_ARGS} ${CONFIG_JSON_ARGS} ${CONFIG_DB_ARGS}&
 
     ztp_engine_pid=$!
     wait "$ztp_engine_pid"

--- a/src/usr/lib/ztp/ztp-profile.sh
+++ b/src/usr/lib/ztp/ztp-profile.sh
@@ -52,6 +52,7 @@ usage()
                    and start DHCP discovery
          remove  - If the switch is running ZTP configuration, reload startup configuration
                    or factory default configuration if startup configuration is missing.
+         discoverOnly - use the config_db.json and start DHCP discovery
 EOF
 }
 


### PR DESCRIPTION
[ZTP] Use config db instead of ZTP configuration profile while dhcp discovery

By adding USE_DEFAULT_CONFIG="no" in /etc/default/ztp for Inband ZTP, it won't generate /tmp/ztp_config_db.json, but use current redis config db during dhcp discovery.

This solves the interface breakout config reset to default mode (or other config, ex: FEC mode) and operation down issue.