### PR TITLE
Add role field to the ztp PORT config

### DIFF
--- a/src/usr/lib/ztp/templates/ztp-config.j2
+++ b/src/usr/lib/ztp/templates/ztp-config.j2
@@ -26,6 +26,9 @@
 {% if PORT[port].fec is defined and PORT[port].fec != "" %}
                 "fec": "{{ PORT[port].fec }}",
 {% endif %}
+{% if PORT[port].role is defined and PORT[port].role != "" %}
+                "role": "{{ PORT[port].role }}",
+{% endif %}
 {% if ZTP_INBAND == "true" %}
                 "admin_status": "up"
 {% else %}


### PR DESCRIPTION
Factory installation of SONiC on a Smartswitch with ZTP enabled is causing xcvrd to crash

```
Jul  5 07:51:38.074836 smartswitch1 ERR pmon#xcvrd: Exception occured at SfpStateUpdateTask thread due to AttributeError("'NoneType' object has no attribute 'get_presence'")
Jul  5 07:51:38.077516 smartswitch1 ERR pmon#xcvrd: Traceback (most recent call last):
Jul  5 07:51:38.077516 smartswitch1 ERR pmon#xcvrd:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 2195, in run
Jul  5 07:51:38.077516 smartswitch1 ERR pmon#xcvrd:     self.task_worker(self.task_stopping_event, self.sfp_error_event)
Jul  5 07:51:38.077516 smartswitch1 ERR pmon#xcvrd:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 2005, in task_worker
Jul  5 07:51:38.077516 smartswitch1 ERR pmon#xcvrd:     self.init()
Jul  5 07:51:38.077556 smartswitch1 ERR pmon#xcvrd:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1923, in init
Jul  5 07:51:38.077586 smartswitch1 ERR pmon#xcvrd:     self.retry_eeprom_set = self._post_port_sfp_info_and_dom_thr_to_db_once(port_mapping_data, self.xcvr_table_helper, self.main_thread_stop_event)
Jul  5 07:51:38.077586 smartswitch1 ERR pmon#xcvrd:                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul  5 07:51:38.077586 smartswitch1 ERR pmon#xcvrd:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 1878, in _post_port_sfp_info_and_dom_thr_to_db_once
Jul  5 07:51:38.077636 smartswitch1 ERR pmon#xcvrd:     rc = post_port_sfp_info_to_db(logical_port_name, port_mapping, xcvr_table_helper.get_intf_tbl(asic_index), transceiver_dict, stop_event)
Jul  5 07:51:38.077735 smartswitch1 ERR pmon#xcvrd:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul  5 07:51:38.077735 smartswitch1 ERR pmon#xcvrd:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 435, in post_port_sfp_info_to_db
Jul  5 07:51:38.077735 smartswitch1 ERR pmon#xcvrd:     if not _wrapper_get_presence(physical_port):
Jul  5 07:51:38.077735 smartswitch1 ERR pmon#xcvrd:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul  5 07:51:38.077770 smartswitch1 ERR pmon#xcvrd:   File "/usr/local/lib/python3.11/dist-packages/xcvrd/xcvrd.py", line 245, in _wrapper_get_presence
Jul  5 07:51:38.077786 smartswitch1 ERR pmon#xcvrd:     return platform_chassis.get_sfp(physical_port).get_presence()
Jul  5 07:51:38.077786 smartswitch1 ERR pmon#xcvrd:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul  5 07:51:38.077831 smartswitch1 ERR pmon#xcvrd: AttributeError: 'NoneType' object has no attribute 'get_presence'
Jul  5 07:51:38.077881 smartswitch1 ERR pmon#xcvrd: Xcvrd: exception found at child thread SfpStateUpdateTask due to AttributeError("'NoneType' object has no attribute 'get_presence'")
Jul  5 07:51:38.077881 smartswitch1 ERR pmon#xcvrd: Exiting main loop as child thread raised exception!
Jul  5 07:51:39.144465 smartswitch1 INFO pmon#supervisord 2024-07-05 07:51:39,143 WARN exited: xcvrd (terminated by SIGKILL; not expected)
```

This is because role is a mandatory attribute for the internal ports of a smartswitch. 

Even though we override the config later, xcvrd crash should be avoided