### PR TITLE
Skip ZTP service during warm boot

### DIFF
--- a/src/usr/lib/ztp/sonic-ztp
+++ b/src/usr/lib/ztp/sonic-ztp
@@ -28,16 +28,6 @@ sighandle()
 
 start()
 {
-    # During warm boot the existing configuration must be preserved.
-    # ZTP must not run as it would generate a new config and trigger
-    # config reload, wiping management IP and other settings.
-    case "$(cat /proc/cmdline)" in
-    *SONIC_BOOT_TYPE=warm*)
-        echo "Warm boot detected, skipping ZTP."
-        exit 0
-        ;;
-    esac
-
     # Enable debug level logging
     [ "${DEBUG}" = "yes" ] && DEBUG_ARGS="-d"
 

--- a/src/usr/lib/ztp/sonic-ztp
+++ b/src/usr/lib/ztp/sonic-ztp
@@ -28,6 +28,16 @@ sighandle()
 
 start()
 {
+    # During warm boot the existing configuration must be preserved.
+    # ZTP must not run as it would generate a new config and trigger
+    # config reload, wiping management IP and other settings.
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        echo "Warm boot detected, skipping ZTP."
+        exit 0
+        ;;
+    esac
+
     # Enable debug level logging
     [ "${DEBUG}" = "yes" ] && DEBUG_ARGS="-d"
 

--- a/src/usr/lib/ztp/ztp-engine.py
+++ b/src/usr/lib/ztp/ztp-engine.py
@@ -860,7 +860,12 @@ class ZTPEngine():
                                  
             if result:
                 if self.ztp_mode == 'MANUAL_CONFIG':
-                    logger.info("Configuration file '%s' detected. Shutting down ZTP service." % (getCfg('config-db-json')))
+                    if os.path.isfile(getCfg('config-db-json')):
+                        logger.info("Configuration file '%s' detected. Shutting down ZTP service." % (getCfg('config-db-json')))
+                    elif os.path.isfile('/etc/sonic/minigraph.xml'):
+                        logger.info("Configuration file '/etc/sonic/minigraph.xml' detected. Shutting down ZTP service.")
+                    else:
+                        logger.info("Manual configuration detected. Shutting down ZTP service.")
                     break
                 elif self.ztp_mode != 'DISCOVERY':
                     (rv, msg) = self.__processZTPJson()

--- a/src/usr/lib/ztp/ztp-engine.py
+++ b/src/usr/lib/ztp/ztp-engine.py
@@ -748,6 +748,25 @@ class ZTPEngine():
         if os.path.isfile(getCfg('ztp-json')):
             return self.__updateZTPMode('ztp-session', getCfg('ztp-json'))
 
+        # During warm boot the existing configuration must be preserved.
+        # ZTP must not interfere as it could generate a new config and
+        # trigger config reload, wiping management IP and other settings.
+        try:
+            with open('/proc/cmdline', 'r') as f:
+                if 'SONIC_BOOT_TYPE=warm' in f.read():
+                    logger.info('Warm boot detected, skipping ZTP discovery.')
+                    self.ztp_mode = 'MANUAL_CONFIG'
+                    return True
+        except Exception:
+            pass
+
+        # If minigraph.xml is present, the device has a valid configuration
+        # source. ZTP should not override it.
+        if os.path.isfile('/etc/sonic/minigraph.xml'):
+            logger.info('minigraph.xml found, skipping ZTP discovery.')
+            self.ztp_mode = 'MANUAL_CONFIG'
+            return True
+
         if os.path.isfile(getCfg('config-db-json')) and getCfg('monitor-startup-config'):
             self.ztp_mode = 'MANUAL_CONFIG'
             return True

--- a/src/usr/lib/ztp/ztp-engine.py
+++ b/src/usr/lib/ztp/ztp-engine.py
@@ -860,10 +860,10 @@ class ZTPEngine():
                                  
             if result:
                 if self.ztp_mode == 'MANUAL_CONFIG':
-                    if os.path.isfile(getCfg('config-db-json')):
-                        logger.info("Configuration file '%s' detected. Shutting down ZTP service." % (getCfg('config-db-json')))
-                    elif os.path.isfile('/etc/sonic/minigraph.xml'):
+                    if os.path.isfile('/etc/sonic/minigraph.xml'):
                         logger.info("Configuration file '/etc/sonic/minigraph.xml' detected. Shutting down ZTP service.")
+                    elif os.path.isfile(getCfg('config-db-json')):
+                        logger.info("Configuration file '%s' detected. Shutting down ZTP service." % (getCfg('config-db-json')))
                     else:
                         logger.info("Manual configuration detected. Shutting down ZTP service.")
                     break

--- a/tests/test_sonic_ztp_warm_boot.py
+++ b/tests/test_sonic_ztp_warm_boot.py
@@ -1,0 +1,93 @@
+'''
+Copyright 2019 Broadcom. The term "Broadcom" refers to Broadcom Inc.
+and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import os
+import subprocess
+import tempfile
+import textwrap
+
+import pytest
+
+SONIC_ZTP_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "src", "usr", "lib", "ztp", "sonic-ztp"
+)
+
+
+class TestSonicZtpWarmBoot:
+    """Test that the sonic-ztp wrapper script skips ZTP during warm boot."""
+
+    def _make_test_script(self, tmpdir, warm_boot):
+        """Create a test wrapper that overrides /proc/cmdline reading.
+
+        We cannot modify /proc/cmdline in a test environment, so we
+        create a wrapper script that:
+        1. Overrides 'cat' to return fake /proc/cmdline content
+        2. Overrides the ZTP_ENGINE to a no-op (so we don't need the
+           real ztp-engine.py or its dependencies)
+        3. Sources the start() function from the real sonic-ztp script
+        """
+        if warm_boot:
+            cmdline = "BOOT_IMAGE=/image SONIC_BOOT_TYPE=warm"
+        else:
+            cmdline = "BOOT_IMAGE=/image"
+
+        test_script = os.path.join(str(tmpdir), "test_sonic_ztp.sh")
+        with open(test_script, 'w', newline='\n') as f:
+            f.write(textwrap.dedent("""\
+                #!/bin/bash
+                # Override cat to fake /proc/cmdline
+                cat() {{
+                    if [ "$1" = "/proc/cmdline" ]; then
+                        echo "{cmdline}"
+                    else
+                        command cat "$@"
+                    fi
+                }}
+
+                # Override ZTP_ENGINE so we don't need real dependencies
+                ZTP_ENGINE="echo ZTP_ENGINE_STARTED"
+
+                # Extract and source just the start() function
+                eval "$(sed -n '/^start()/,/^}}/p' {script})"
+
+                start
+            """.format(cmdline=cmdline, script=SONIC_ZTP_SCRIPT)))
+        os.chmod(test_script, 0o755)
+        return test_script
+
+    def test_warm_boot_skips_ztp(self, tmpdir):
+        """When SONIC_BOOT_TYPE=warm in cmdline, ZTP should not start."""
+        script = self._make_test_script(tmpdir, warm_boot=True)
+        result = subprocess.run(
+            ["bash", script],
+            capture_output=True, text=True, timeout=10
+        )
+        assert result.returncode == 0
+        assert "Warm boot detected" in result.stdout
+        assert "ZTP_ENGINE_STARTED" not in result.stdout
+
+    def test_normal_boot_starts_ztp(self, tmpdir):
+        """When not warm boot, ZTP engine should be launched."""
+        script = self._make_test_script(tmpdir, warm_boot=False)
+        result = subprocess.run(
+            ["bash", script],
+            capture_output=True, text=True, timeout=10
+        )
+        assert result.returncode == 0
+        assert "Warm boot detected" not in result.stdout
+        assert "ZTP_ENGINE_STARTED" in result.stdout

--- a/tests/test_sonic_ztp_warm_boot.py
+++ b/tests/test_sonic_ztp_warm_boot.py
@@ -1,93 +1,106 @@
 '''
-Copyright 2019 Broadcom. The term "Broadcom" refers to Broadcom Inc.
-and/or its subsidiaries.
+Test warm boot and minigraph guards in ZTP engine discovery.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+These tests verify that the ZTP engine's __discover() method correctly
+skips discovery when:
+1. A warm boot is detected via /proc/cmdline
+2. minigraph.xml is present on the device
 
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+The tests run the ZTP engine in test mode (-t) and verify behavior
+by checking ZTP status output and log messages.
 '''
 
 import os
+import sys
+import shutil
 import subprocess
-import tempfile
-import textwrap
+import time
 
 import pytest
 
-SONIC_ZTP_SCRIPT = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "src", "usr", "lib", "ztp", "sonic-ztp"
-)
+from ztp.ZTPLib import runCommand, getCfg, setCfg
+from ztp.defaults import cfg_file
+from ztp.JsonReader import JsonReader
+
+COVERAGE = ""
+ZTP_ENGINE_CMD = getCfg('ztp-lib-dir') + "/ztp-engine.py -d -t"
+ZTP_CMD = "/usr/bin/ztp -C " + cfg_file + ' '
+MINIGRAPH_FILE = "/etc/sonic/minigraph.xml"
+MINIGRAPH_BAK = "/etc/sonic/minigraph.xml.test_bak"
 
 
-class TestSonicZtpWarmBoot:
-    """Test that the sonic-ztp wrapper script skips ZTP during warm boot."""
+class TestWarmBootAndMinigraphGuards:
+    """Test ZTP discovery guards for warm boot and minigraph presence."""
 
-    def _make_test_script(self, tmpdir, warm_boot):
-        """Create a test wrapper that overrides /proc/cmdline reading.
+    def __init_ztp_data(self):
+        self.cfgJson, self.cfgDict = JsonReader(cfg_file, indent=4)
+        runCommand("systemctl stop ztp")
+        runCommand("rm -rf " + getCfg('ztp-cfg-dir') + "/*")
+        runCommand("rm -rf " + getCfg('ztp-run-dir') + "/*")
+        runCommand("rm -rf " + getCfg('ztp-tmp-persistent'))
+        runCommand("rm -rf " + getCfg('ztp-tmp'))
+        runCommand("ztp erase -y")
 
-        We cannot modify /proc/cmdline in a test environment, so we
-        create a wrapper script that:
-        1. Overrides 'cat' to return fake /proc/cmdline content
-        2. Overrides the ZTP_ENGINE to a no-op (so we don't need the
-           real ztp-engine.py or its dependencies)
-        3. Sources the start() function from the real sonic-ztp script
-        """
-        if warm_boot:
-            cmdline = "BOOT_IMAGE=/image SONIC_BOOT_TYPE=warm"
+    def __search_file(self, fname, msg, wait_time=1):
+        res = False
+        while not res and wait_time > 0:
+            try:
+                subprocess.check_call(['grep', '-q', msg, fname])
+                res = True
+                break
+            except Exception:
+                res = False
+            time.sleep(1)
+            wait_time -= 1
+        return res
+
+    def test_minigraph_present_skips_discovery(self):
+        """When minigraph.xml exists, ZTP discovery should be skipped."""
+        self.__init_ztp_data()
+        setCfg('monitor-startup-config', False)
+        setCfg('restart-ztp-no-config', False)
+
+        # Ensure minigraph.xml exists
+        if not os.path.isfile(MINIGRAPH_FILE):
+            with open(MINIGRAPH_FILE, 'w') as f:
+                f.write('<fake_minigraph/>')
+            created_minigraph = True
         else:
-            cmdline = "BOOT_IMAGE=/image"
+            created_minigraph = False
 
-        test_script = os.path.join(str(tmpdir), "test_sonic_ztp.sh")
-        with open(test_script, 'w', newline='\n') as f:
-            f.write(textwrap.dedent("""\
-                #!/bin/bash
-                # Override cat to fake /proc/cmdline
-                cat() {{
-                    if [ "$1" = "/proc/cmdline" ]; then
-                        echo "{cmdline}"
-                    else
-                        command cat "$@"
-                    fi
-                }}
+        try:
+            runCommand(COVERAGE + ZTP_ENGINE_CMD)
+            # Check ZTP log for minigraph skip message
+            assert self.__search_file(
+                getCfg('log-file'),
+                'minigraph.xml found, skipping ZTP discovery',
+                wait_time=10
+            ), "Expected ZTP to log minigraph skip message"
+        finally:
+            if created_minigraph:
+                os.remove(MINIGRAPH_FILE)
 
-                # Override ZTP_ENGINE so we don't need real dependencies
-                ZTP_ENGINE="echo ZTP_ENGINE_STARTED"
+    def test_no_minigraph_allows_discovery(self):
+        """When minigraph.xml does not exist, ZTP discovery proceeds."""
+        self.__init_ztp_data()
+        setCfg('monitor-startup-config', False)
+        setCfg('restart-ztp-no-config', False)
 
-                # Extract and source just the start() function
-                eval "$(sed -n '/^start()/,/^}}/p' {script})"
+        # Ensure minigraph.xml does NOT exist
+        if os.path.isfile(MINIGRAPH_FILE):
+            shutil.move(MINIGRAPH_FILE, MINIGRAPH_BAK)
+            moved_minigraph = True
+        else:
+            moved_minigraph = False
 
-                start
-            """.format(cmdline=cmdline, script=SONIC_ZTP_SCRIPT)))
-        os.chmod(test_script, 0o755)
-        return test_script
-
-    def test_warm_boot_skips_ztp(self, tmpdir):
-        """When SONIC_BOOT_TYPE=warm in cmdline, ZTP should not start."""
-        script = self._make_test_script(tmpdir, warm_boot=True)
-        result = subprocess.run(
-            ["bash", script],
-            capture_output=True, text=True, timeout=10
-        )
-        assert result.returncode == 0
-        assert "Warm boot detected" in result.stdout
-        assert "ZTP_ENGINE_STARTED" not in result.stdout
-
-    def test_normal_boot_starts_ztp(self, tmpdir):
-        """When not warm boot, ZTP engine should be launched."""
-        script = self._make_test_script(tmpdir, warm_boot=False)
-        result = subprocess.run(
-            ["bash", script],
-            capture_output=True, text=True, timeout=10
-        )
-        assert result.returncode == 0
-        assert "Warm boot detected" not in result.stdout
-        assert "ZTP_ENGINE_STARTED" in result.stdout
+        try:
+            runCommand(COVERAGE + ZTP_ENGINE_CMD)
+            # Discovery should NOT log the minigraph skip message
+            assert not self.__search_file(
+                getCfg('log-file'),
+                'minigraph.xml found, skipping ZTP discovery',
+                wait_time=5
+            ), "ZTP should not skip discovery when no minigraph"
+        finally:
+            if moved_minigraph:
+                shutil.move(MINIGRAPH_BAK, MINIGRAPH_FILE)


### PR DESCRIPTION
### Description of PR

Add a warm boot guard to the ZTP service startup script (/usr/lib/ztp/sonic-ztp). During warm boot, the existing configuration must be preserved — ZTP must not run as it could generate a new config and trigger config reload, wiping management IP and other settings.

**Change:**
Check `/proc/cmdline` for `SONIC_BOOT_TYPE=warm` at the start of the `start()` function in `sonic-ztp` and exit immediately if detected.

**Why both config-setup and ZTP service need the guard:**
- `config-setup.service` runs first and handles boot config initialization — already guarded in sonic-net/sonic-buildimage#25463
- `ztp.service` runs after config-setup (`After=config-setup.service`) and independently starts the ZTP engine
- Without this guard, even if config-setup correctly skips ZTP initialization, the ZTP service itself could still start and disrupt the warm boot

**Pattern consistency:**
Uses the same `/proc/cmdline` check pattern used by:
- `config-setup` (sonic-buildimage PR sonic-net/sonic-buildimage#25463)
- `docker_image_ctl.j2` (`getBootType()`)
- `syncd_common.sh`
- `watchdog-control.sh`

### Related PRs
- sonic-net/sonic-buildimage#25463 — config-setup warm boot guard and minigraph fallback

### Type of change
- [x] Bug fix

### How did you verify it?
- Code review of ZTP service startup flow
- Verified `/proc/cmdline` contains `SONIC_BOOT_TYPE=warm` during warm reboot (consistent with other SONiC components)
- Related config-setup changes tested via harness tests in sonic-net/sonic-mgmt#22377