### PR TITLE
Fix variable name typo in graphservice ZTP plugin

### DIFF
--- a/src/usr/lib/ztp/plugins/graphservice
+++ b/src/usr/lib/ztp/plugins/graphservice
@@ -35,7 +35,7 @@ def processData(dict, app_name, dest_file):
  
   if app_data.get('dynamic-url') is not None:
      objURL  = DynamicURL(app_data.get('dynamic-url'), dest_file)
-     url_str = objDynURL.getSource()
+     url_str = objURL.getSource()
   elif app_data.get('url') is not None:
      objURL = URL(app_data.get('url'), dest_file)
      url_str = objURL.getSource()


### PR DESCRIPTION
## Why I did it

The `graphservice` ZTP plugin has a variable name typo that causes a `NameError` when using `dynamic-url` for minigraph download. The DynamicURL object is assigned to `objURL` but referenced as `objDynURL` on the next line, so any ZTP config using dynamic URLs for minigraph fails silently.

Fixes #73

## How I did it

Changed `objDynURL.getSource()` to `objURL.getSource()` in the `processData()` function.

## How to verify it

1. Configure ZTP with a `dynamic-url` source for `minigraph-url`
2. Trigger ZTP on a switch
3. Verify the minigraph is downloaded successfully (previously would fail with `NameError`)

---
*This PR was created by an AI agent on behalf of @yxieca.*

Signed-off-by: Ying Xie <ying.xie@microsoft.com>