### PR TITLE
[ZTP] Add vendor specific hook to check link state

### DIFF
--- a/src/usr/lib/ztp/ztp-engine.py
+++ b/src/usr/lib/ztp/ztp-engine.py
@@ -35,6 +35,53 @@ from ztp.Logger import logger
 from ztp.ZTPLib import getTimestamp, runCommand, runcmd_pids 
 from ztp.ZTPLib import getField, getCfg, validateZtpCfg, updateActivity, systemReboot
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
+import sonic_platform.platform
+
+
+def _get_kernel_operstate(intf):
+    """!
+    Read the kernel-reported operstate for a network interface.
+
+    @return 'up', 'down', or other kernel operstate string.
+    """
+    with open("/sys/class/net/{}/operstate".format(intf), "r") as fh:
+        return fh.readline().strip().lower()
+
+
+def _has_platform_mgmt_link_check():
+    """!
+    Check whether this platform overrides the kernel-reported management port
+    link status via the platform API (get_management_port_link_status_override).
+    """
+    try:
+        chassis = sonic_platform.platform.Platform().get_chassis()
+    except Exception:
+        return False
+    return hasattr(chassis, "get_management_port_link_status_override")
+
+
+def _platform_mgmt_link_check(intf):
+    """!
+    Query the platform for the real management port link status via the
+    platform API. If the platform provides an override (returns True/False),
+    use it instead of the kernel operstate. If not implemented (returns None)
+    or on error, return None to fall back to the kernel operstate.
+
+    @return 'up' if the platform reports link up;
+            'down' if the platform reports link down;
+            None if the platform does not override or on error.
+    """
+    try:
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        is_up = chassis.get_management_port_link_status_override(intf)
+    except Exception as e:
+        logger.warning("get_management_port_link_status_override failed: %s" % str(e))
+        return None
+    if is_up is None:
+        return None
+    logger.debug("Platform mgmt link check: %s" % ("up" if is_up else "down"))
+    return "up" if is_up else "down"
+
 
 def check_pid(pid):
     ## Check For the existence of a unix pid
@@ -157,9 +204,9 @@ class ZTPEngine():
         for intf in natsorted(intf_list):
             try:
                 if intf[0:3] == 'eth':
-                    fh = open('/sys/class/net/{}/operstate'.format(intf), 'r')
-                    operstate = fh.readline().strip().lower()
-                    fh.close()
+                    override = _platform_mgmt_link_check(intf) if _has_platform_mgmt_link_check() else None
+                    operstate = override if override is not None else _get_kernel_operstate(intf)
+
                 else:
                     if self.applDB.exists(self.applDB.APPL_DB, 'PORT_TABLE:'+intf):
                         port_entry = self.applDB.get_all(self.applDB.APPL_DB, 'PORT_TABLE:'+intf)

--- a/src/usr/lib/ztp/ztp-engine.py
+++ b/src/usr/lib/ztp/ztp-engine.py
@@ -67,9 +67,11 @@ def _platform_mgmt_link_check(intf):
     use it instead of the kernel operstate. If not implemented (returns None)
     or on error, return None to fall back to the kernel operstate.
 
-    @return 'up' if the platform reports link up;
-            'down' if the platform reports link down;
-            None if the platform does not override or on error.
+   @return 'up'   if the platform override reports link up;
+           'down' if the platform override reports link down;
+           None   if the platform does not override (not implemented or
+                  error), in which case ZTP falls back to the kernel link
+                  state (/sys/class/net/<port>/operstate).
     """
     try:
         chassis = sonic_platform.platform.Platform().get_chassis()


### PR DESCRIPTION
**What I did**
Use `get_management_port_link_status_override` from sonic platform API introduced by https://github.com/sonic-net/sonic-platform-common/pull/654 to determine management port link status for ZTP.

**Why I did it**

Nexthop's platforms have an unmanaged switch sitting between the front panel rj45 and the CPU's eth0.
As a result eth0's link state as advertised by the kernel (`/sys/class/net/eth0/operstate`), does not reflect the state of the rj45.

e.g.
```
Front Panel RJ45 (Management Port)
         |
        A
         |
    BCM53134 Switch (management switch running in unmanaged mode)
       /    \
      B      C
     /        \
    BMC    CPU (eth0)
```
Link `A` may be down (if RJ45 for example is unplugged), but link `C` (`/sys/class/net/eth0/operstate`) still says up.

in this PR we avoid needlessly attempting to access eth0 (eth0 is just an example, can be any management port) in ZTP if eth0 is down on platforms where `/sys/class/net/eth0/operstate` link being up is not enough information to indicate management port being up.


