### PR TITLE
[chore/github]: Standardize GitHub PR description template

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -132,6 +132,11 @@ python3 -m pytest --cov=ztp -v
 - **Plugin changes**: Include plugin script and corresponding test
 - **Reference**: Link to [SONiC ZTP HLD](https://github.com/Azure/SONiC/blob/master/doc/ztp/ztp.md) for design context
 - **Test coverage**: New features and plugins must have test coverage
+- **PR description template**: Fill out all sections of the [PR template](.github/pull_request_template.md) when submitting a pull request:
+  - **Description of PR**: Summary of the change, motivation/context, reviewer entry point, and dependencies; reference issues with `fixes #xxxx` / `closes #xxxx`.
+  - **Type of change**: Mark the box(es) that apply — bug fix, new feature, refactor / cleanup, documentation update, test improvement.
+  - **Approach**: Motivation; how you did it; how you verified/tested it; any platform-specific notes.
+  - **Documentation**: Link to wiki / doc updates relevant to new features or test cases.
 
 ## Dependencies
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md
+
+Please provide following information to help code review process a bit easier:
+-->
+### Description of PR
+<!--
+- Please include a summary of the change and which issue is fixed.
+- Please also include relevant motivation and context. Where should reviewer start? background context?
+- List any dependencies that are required for this change.
+-->
+
+Summary:
+Fixes # (issue)
+
+### Type of change
+
+<!--
+- Fill x for your type of change.
+- e.g.
+- [x] Bug fix
+-->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation update
+- [ ] Test improvement
+
+### Approach
+#### What is the motivation for this PR?
+
+#### How did you do it?
+
+#### How did you verify/test it?
+
+#### Any platform specific information?
+
+### Documentation
+<!--
+(If it's a new feature, new test case)
+Did you update documentation/Wiki relevant to your implementation?
+Link to the wiki page?
+-->


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR

Summary:
Align this repository's GitHub PR description template with the canonical
template used in [`sonic-buildimage`](https://github.com/sonic-net/sonic-buildimage/blob/master/.github/pull_request_template.md),
so contributors see the same prompts (Description of PR, Type of change,
Approach, Documentation) everywhere across SONiC.

Also update `.github/copilot-instructions.md` so AI-assisted PR descriptions
reference the new template sections.

Fixes # (issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?

PR description templates across SONiC repositories have drifted from the
canonical `sonic-buildimage` template over time. A single shared structure
makes reviews predictable: contributors see the same prompts everywhere, and
reviewers can locate the same information in the same place across submodules.

#### How did you do it?

- Replaced `.github/pull_request_template.md` with the canonical `sonic-buildimage` template.
- Updated `.github/copilot-instructions.md` so the "PR description template" guidance lists the sections defined by the new template (Description of PR, Type of change, Approach, Documentation).

#### How did you verify/test it?

No functional changes — only files under `.github/` are touched. Verified by
rendering the new template on GitHub when opening this PR and confirming all
sections appear correctly.

#### Any platform specific information?

None.

### Documentation

N/A — process/template change only.
